### PR TITLE
Add handler for values less than 1

### DIFF
--- a/lib/to_duration/converter.rb
+++ b/lib/to_duration/converter.rb
@@ -42,7 +42,7 @@ module ToDuration
     }.freeze
 
     def to_units
-      return ['Less than 1 second'] if @value < 1
+      return ["< 1 #{I18n.t('to_duration.second', count: 1)}"] if @value < 1
       seconds = @value
 
       UNITS.map do |k, v|

--- a/lib/to_duration/converter.rb
+++ b/lib/to_duration/converter.rb
@@ -42,6 +42,7 @@ module ToDuration
     }.freeze
 
     def to_units
+      return ["Less than 1 second"] if @value < 1
       seconds = @value
 
       UNITS.map do |k, v|

--- a/lib/to_duration/converter.rb
+++ b/lib/to_duration/converter.rb
@@ -42,7 +42,7 @@ module ToDuration
     }.freeze
 
     def to_units
-      return ["Less than 1 second"] if @value < 1
+      return ['Less than 1 second'] if @value < 1
       seconds = @value
 
       UNITS.map do |k, v|

--- a/test/to_duration_test.rb
+++ b/test/to_duration_test.rb
@@ -10,7 +10,7 @@ class ToDurationTest < ToDuration::Test
   end
 
   def test_time
-    assert_equal 'Less than 1 second', 0.1.to_duration
+    assert_equal '< 1 second', 0.1.to_duration
     assert_equal '1 second', 1.to_duration
     assert_equal '1 hour, 1 minute and 1 second', 3661.to_duration
     assert_equal '2 hours, 2 minutes and 2 seconds', 7322.to_duration

--- a/test/to_duration_test.rb
+++ b/test/to_duration_test.rb
@@ -10,6 +10,7 @@ class ToDurationTest < ToDuration::Test
   end
 
   def test_time
+    assert_equal 'Less than 1 second', 0.1.to_duration
     assert_equal '1 second', 1.to_duration
     assert_equal '1 hour, 1 minute and 1 second', 3661.to_duration
     assert_equal '2 hours, 2 minutes and 2 seconds', 7322.to_duration


### PR DESCRIPTION
Before this change, the `to_duration` method returned an empty string ("") when it was called on a value less than 1. With this change, it will now return "Less than 1 second".